### PR TITLE
Introducing some tuning variables

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,23 @@ defaults to only executing on AMD Family 19h and later CPUs.
 A full listing of the interfaces to libhsmp with explanations is
 available in libhsmp.h.
 
+2.1. Environment Variables
+==========================
+
+2.1.1. LIBHSMP_WAIT_TIME
+The environment variable LIBHSMP_WAIT_TIME sets the time libhsmp waits
+before polling the answer on a request in nanoseconds. By default
+libhsmp waits 1,000,000 ns (i.e., 1 ms). You can lower the time by
+setting this variable to something between 0 (busy-waiting) and
+1000000 as a waiting time in nanoseconds.
+
+2.1.2. LIBHSMP_FAM17_WARNING
+The environment variable LIBHSMP_FAM17_WARNING allows you to disable
+the Family 17h warning, which could trigger some errors if stderr is
+parsed by a error checking tool. By setting LIBHSMP_FAM17_WARNING to
+"0", "n", "N", or "No" you can disable the warning message
+" WARNING: libhsmp not supported ...".
+
 3. Errors
 =========
 

--- a/libhsmp.c
+++ b/libhsmp.c
@@ -331,7 +331,9 @@ static int _hsmp_send_message(struct pci_dev *root_dev, struct hsmp_message *msg
 	 * more. So first thing we do is yield the CPU.
 	 */
 retry:
-	nanosleep(&one_ms, NULL);
+	if (idle_wait_time_in_ns > 0)
+		nanosleep(&one_ms, NULL);
+
 	err = smu_pci_read(root_dev, hsmp_access.mbox_status, &mbox_status, &hsmp);
 	if (err) {
 		pr_debug("HSMP message ID %u - error %d reading mailbox status\n",


### PR DESCRIPTION
This patch introduces two environment variables:
- LIBHSMP_WAIT_TIME defines the wait time after sending a request message to the SMU in nanoseconds. It can be set to 0 for busy waiting.
- LIBHSMP_FAM17_WARNING can be used to disable the Fam17h warning message